### PR TITLE
Install APCu stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y git curl bzip2 vim libssl-dev zlib1g-dev libxrender1 libicu-dev g++ libjpeg-dev libjpeg62 libfontconfig-dev \
     && pecl install xdebug \
     && echo zend_extension=xdebug.so > /usr/local/etc/php/conf.d/xdebug.ini \
-    && pecl install apcu-beta \
+    && pecl install apcu \
     && echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini \
     && docker-php-ext-install zip mbstring intl pdo_mysql \
     && apt-get -y install mysql-client php5-gd


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
